### PR TITLE
Added recurse submodules

### DIFF
--- a/vcs/git.go
+++ b/vcs/git.go
@@ -48,11 +48,11 @@ func (ctx *GitVCSCtx) Import(branch, commit string, depth int64) error {
 	}
 	_, fn := filepath.Split(ctx.Root)
 	if depth < 1 {
-		if _, err := ctx.runCmdInParent("clone", "-b", branch, ctx.URL, fn); err != nil {
+		if _, err := ctx.runCmdInParent("clone", "--recurse-submodules", "-b", branch, ctx.URL, fn); err != nil {
 			return err
 		}
 	} else {
-		if _, err := ctx.runCmdInParent("clone", "--depth", strconv.Itoa(int(depth)), "-b", branch, ctx.URL, fn); err != nil {
+		if _, err := ctx.runCmdInParent("clone", "--recurse-submodules", "--depth", strconv.Itoa(int(depth)), "-b", branch, ctx.URL, fn); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Recurse submodules by default.

Imported modules may be using git submodules, and hence it makes sense to recurse submodules by default to make a `mdlr import` operation perform all the required steps to get the submodule including dependencies.