### PR TITLE
fix(sh): Install script can be run multiple times now

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ GH_URL='https://github.com/exlinc/mdlr/releases/download'
 VERSION='v1.0.0'
 echo "Preparing to install mdlr@$VERSION ..."
 echo "Creating temp directory ..."
-mkdir .mdlr-install
+mkdir -p .mdlr-install
 cd  .mdlr-install
 echo "Temp directory created ..."
 


### PR DESCRIPTION
Before that, mkdir would return "cannot create directory .mdlr-install: File exists" if the file existed